### PR TITLE
silence unhandled TypeError logs

### DIFF
--- a/lib/pull.js
+++ b/lib/pull.js
@@ -39,6 +39,11 @@ function pull (state, options, docsOrIds) {
   var replication = this.replicate.from(options.remote, {
     doc_ids: docsOrIds
   })
+
+  replication.catch(function () {
+    // handled trough 'error' event
+  })
+
   replication.on('complete', function () {
     defer.resolve(pulledObjects)
   })

--- a/lib/push.js
+++ b/lib/push.js
@@ -41,6 +41,10 @@ function push (state, options, docsOrIds) {
     include_docs: true
   })
 
+  replication.catch(function () {
+    // handled trough 'error' event
+  })
+
   replication.on('complete', function () {
     defer.resolve(pushedObjects)
   })

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -41,6 +41,10 @@ function sync (state, options, docsOrIds) {
     include_docs: true
   })
 
+  replication.catch(function () {
+    // handled trough 'error' event
+  })
+
   replication.on('complete', function () {
     defer.resolve(syncedObjects)
   })

--- a/tests/specs/pull.js
+++ b/tests/specs/pull.js
@@ -204,12 +204,7 @@ test('api.push() error', function (t) {
   .then(function () {
     return api.pull(data)
   })
-  .then(
-    function (resolve) {
-      t.pass('The error event was not fired!')
-    },
-    function (reject) {
-      t.pass('The error event was fired!')
-    }
-  )
+  .catch(function () {
+    t.pass('The error event was fired!')
+  })
 })

--- a/tests/specs/push.js
+++ b/tests/specs/push.js
@@ -204,12 +204,7 @@ test('api.push() error', function (t) {
   .then(function () {
     return api.push(data)
   })
-  .then(
-    function (resolve) {
-      t.pass('The error event was not fired!')
-    },
-    function (reject) {
-      t.pass('The error event was fired!')
-    }
-  )
+  .catch(function () {
+    t.pass('The error event was fired!')
+  })
 })

--- a/tests/specs/sync.js
+++ b/tests/specs/sync.js
@@ -323,21 +323,21 @@ test('api.sync(error)', function (t) {
 
   var remoteObj1 = {_id: 'test1', foo1: 'bar1'}
   var remoteObj2 = {_id: 'test2', foo1: 'bar2'}
-  db17.bulkDocs([remoteObj1, remoteObj2, data])
 
   var localObj1 = {_id: 'test3', foo1: 'bar3'}
   var localObj2 = {_id: 'test4', foo1: 'bar4'}
-  db18.bulkDocs([localObj1, localObj2])
+
+  db17.bulkDocs([remoteObj1, remoteObj2, data])
+
+  .then(function () {
+    return db18.bulkDocs([localObj1, localObj2])
+  })
 
   .then(function () {
     return api.sync(data)
   })
-  .then(
-    function (resolve) {
-      t.pass('The error event was not fired!')
-    },
-    function (reject) {
-      t.pass('The error event was fired!')
-    }
-  )
+
+  .catch(function () {
+    t.pass('The error event was fired!')
+  })
 })


### PR DESCRIPTION
before, you'd see such logs (e.g. when running tests with `node tests/`)

```
Possibly unhandled TypeError: key must be a string but Got [object Object]
    at LazyMap.mangle (/Users/gregor/JavaScripts/hood.ie/pouchdb-hoodie-sync/node_modules/pouchdb/node_modules/pouchdb-collections/index.js:10:11)
    at LazyMap.set (/Users/gregor/JavaScripts/hood.ie/pouchdb-hoodie-sync/node_modules/pouchdb/node_modules/pouchdb-collections/index.js:26:22)
    at LazySet.add (/Users/gregor/JavaScripts/hood.ie/pouchdb-hoodie-sync/node_modules/pouchdb/node_modules/pouchdb-collections/index.js:63:21)
    at new LazySet (/Users/gregor/JavaScripts/hood.ie/pouchdb-hoodie-sync/node_modules/pouchdb/node_modules/pouchdb-collections/index.js:58:12)
    at PouchAlt.LevelPouch.api._changes (/Users/gregor/JavaScripts/hood.ie/pouchdb-hoodie-sync/node_modules/pouchdb/lib/adapters/leveldb/leveldb.js:908:34)
    at Changes.doChanges (/Users/gregor/JavaScripts/hood.ie/pouchdb-hoodie-sync/node_modules/pouchdb/lib/changes.js:182:28)
    at new Changes (/Users/gregor/JavaScripts/hood.ie/pouchdb-hoodie-sync/node_modules/pouchdb/lib/changes.js:95:10)
    at PouchAlt.AbstractPouchDB.changes (/Users/gregor/JavaScripts/hood.ie/pouchdb-hoodie-sync/node_modules/pouchdb/lib/adapter.js:680:10)
    at getChanges (/Users/gregor/JavaScripts/hood.ie/pouchdb-hoodie-sync/node_modules/pouchdb/lib/replicate/replicate.js:332:23)
    at /Users/gregor/JavaScripts/hood.ie/pouchdb-hoodie-sync/node_modules/pouchdb/lib/replicate/replicate.js:376:9
    at tryCatch1 (/Users/gregor/JavaScripts/hood.ie/pouchdb-hoodie-sync/node_modules/pouchdb/node_modules/bluebird/js/main/util.js:63:19)
    at Promise$_callHandler [as _callHandler] (/Users/gregor/JavaScripts/hood.ie/pouchdb-hoodie-sync/node_modules/pouchdb/node_modules/bluebird/js/main/promise.js:695:13)
    at Promise$_settlePromiseFromHandler [as _settlePromiseFromHandler] (/Users/gregor/JavaScripts/hood.ie/pouchdb-hoodie-sync/node_modules/pouchdb/node_modules/bluebird/js/main/promise.js:711:18)
```