### PR TITLE
Optional EventEmitter

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var EventEmitter = require('events').EventEmitter
 
 function hoodieSync (options) {
   var state = {
-    emitter: new EventEmitter()
+    emitter: options && options.emitter || new EventEmitter()
   }
 
   return {

--- a/tests/specs/constructor.js
+++ b/tests/specs/constructor.js
@@ -1,5 +1,6 @@
 var test = require('tape')
 var dbFactory = require('../utils/db')
+var EventEmitter = require('events').EventEmitter
 
 test('returns hoodie.store-inspired API', function (t) {
   t.plan(3)
@@ -12,4 +13,17 @@ test('returns hoodie.store-inspired API', function (t) {
 
   t.is(typeof store, 'object', 'is object')
   t.is(store.db, db, 'exposes db')
+})
+
+test('creates store with custom EventEmitter instance', function (t) {
+  t.plan(1)
+
+  var db = dbFactory()
+  var emitter = new EventEmitter()
+  var store = db.hoodieSync({emitter: emitter})
+
+  store.on('foo', function () {
+    t.ok('emitter used from options')
+  })
+  emitter.emit('foo')
 })


### PR DESCRIPTION
This PR adds an option to the `hoodieSync()` constructor for an EventEmitter instance. This is useful for cases like `pouchdb-hoodie-store` to control the EventEmitter while combining two PouchDB plugins or creating custom events through the same emitter in an app. 
