### PR TITLE
api.connect to start sync with retry: true

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -15,8 +15,17 @@ function connect (state, options) {
     state.replication = this.sync(options.remote, {
       create_target: true,
       live: true,
-      retry: true,
-      since: 'now'
+      retry: true
+    })
+
+    state.replication.on('error', function (error) {
+      state.emitter.emit('error', error)
+    })
+
+    state.replication.on('change', function (change) {
+      for (var i = 0; i < change.change.docs.length; i++) {
+        state.emitter.emit(change.direction, change.change.docs[i])
+      }
     })
 
     state.emitter.emit('connect')

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -13,8 +13,10 @@ function connect (state, options) {
 
   if (!state.replication) {
     state.replication = this.sync(options.remote, {
+      create_target: true,
       live: true,
-      create_target: true
+      retry: true,
+      since: 'now'
     })
 
     state.emitter.emit('connect')

--- a/tests/specs/connect.js
+++ b/tests/specs/connect.js
@@ -1,5 +1,8 @@
+var PouchDB = require('pouchdb')
 var test = require('tape')
+
 var dbFactory = require('../utils/db')
+var connect = require('../../lib/connect')
 
 /* create if db does not exist, ping if exists or created */
 test('api.connect()', function (t) {
@@ -10,4 +13,29 @@ test('api.connect()', function (t) {
   api.connect().then(function () {
     t.pass('connection is open')
   })
+})
+
+test('connect options', function (t) {
+  var state = {
+    emitter: {
+      emit: function () {}
+    }
+  }
+  var syncArgs
+  connect.bind({
+    constructor: PouchDB,
+    sync: function () {
+      syncArgs = arguments
+      return {
+        on: function () {}
+      }
+    }
+  })(state, {remote: 'remoteDb'})
+
+  t.is(syncArgs[0], 'remoteDb', 'calls api.sync with "remoteDb"')
+  t.is(syncArgs[1].live, true, 'calls api.sync with live: true')
+  t.is(syncArgs[1].retry, true, 'calls api.sync with retry: true')
+  t.is(syncArgs[1].create_target, true, 'calls api.sync with create_target: true')
+  t.is(syncArgs[1].since, 'now', 'calls api.sync with since: "now"')
+  t.end()
 })

--- a/tests/specs/connect.js
+++ b/tests/specs/connect.js
@@ -2,6 +2,8 @@ var PouchDB = require('pouchdb')
 var test = require('tape')
 
 var dbFactory = require('../utils/db')
+var waitFor = require('../utils/wait-for')
+
 var connect = require('../../lib/connect')
 
 /* create if db does not exist, ping if exists or created */
@@ -13,12 +15,58 @@ test('api.connect()', function (t) {
   api.connect().then(function () {
     t.pass('connection is open')
   })
+
+  .catch(t.fail)
+})
+
+test('api.connect() syncs docs', function (t) {
+  t.plan(2)
+  var db1 = dbFactory('connectDB1')
+  var db2 = dbFactory('connectDB2')
+  var api = db1.hoodieSync({remote: db2})
+
+  var pullEvents = []
+  var pushEvents = []
+  api.on('pull', pullEvents.push.bind(pullEvents))
+  api.on('push', pushEvents.push.bind(pushEvents))
+
+  return api.connect()
+
+  .then(function () {
+    db1.put({_id: 'a'})
+  })
+
+  .then(waitFor(function () {
+    // I think 1 should be correct here, see
+    // https://github.com/pouchdb/pouchdb/issues/4293
+    return pushEvents.length >= 1
+  }, true))
+
+  .then(function () {
+    db2.put({_id: 'b'})
+  })
+
+  .then(waitFor(function () {
+    return pullEvents.length >= 1
+  }, true))
+
+  .then(function () {
+    t.ok(pullEvents.length, 'triggers pull event')
+    t.ok(pushEvents.length, 'triggers push event')
+  })
+
+  .catch(t.fail)
 })
 
 test('connect options', function (t) {
+  var errorEvents = []
   var state = {
     emitter: {
-      emit: function () {}
+      emit: function (event) {
+        if (event === 'error') {
+          errorEvents.push(arguments)
+        }
+      }
     }
   }
   var syncArgs
@@ -27,7 +75,11 @@ test('connect options', function (t) {
     sync: function () {
       syncArgs = arguments
       return {
-        on: function () {}
+        on: function (event, callback) {
+          if (event === 'error') {
+            callback('foo')
+          }
+        }
       }
     }
   })(state, {remote: 'remoteDb'})
@@ -36,6 +88,7 @@ test('connect options', function (t) {
   t.is(syncArgs[1].live, true, 'calls api.sync with live: true')
   t.is(syncArgs[1].retry, true, 'calls api.sync with retry: true')
   t.is(syncArgs[1].create_target, true, 'calls api.sync with create_target: true')
-  t.is(syncArgs[1].since, 'now', 'calls api.sync with since: "now"')
+  t.is(errorEvents.length, 1, 'listens to error event')
+  t.is(errorEvents[0][1], 'foo', 'emits error on API')
   t.end()
 })


### PR DESCRIPTION
On `api.connect` we currently do `api.sync` with `live: true`,
but without `retry: true`, which means it doesn't try to reconnect
when for example a connection gets lost, see http://pouchdb.com/api.html#replication

That PR fixes that