### PR TITLE
update semantic-release to version 6.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "istanbul-coveralls": "^1.0.3",
     "memdown": "^1.1.2",
     "pouchdb": "^6.0.4",
-    "semantic-release": "^4.3.4",
+    "semantic-release": "^6.3.2",
     "simple-mock": "^0.7.0",
     "standard": "^8.0.0",
     "tap-spec": "^4.1.0",


### PR DESCRIPTION
For some reason, no new version was released by https://github.com/hoodiehq/pouchdb-hoodie-sync/commit/d236db413c1b5c08bb47a76a94451cc53a461983. I hope upgrading to latest semantic-release will fix it :pray: